### PR TITLE
Simplify public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,7 @@ pip install elma
 
 ### Creating a simple level
 ```python
-from elma.models import Level
-from elma.models import Obj
-from elma.models import Picture
-from elma.models import Point
-from elma.models import Polygon
-
+from elma import Level, Obj, Picture, Point, Polygon
 
 level = Level()
 level.name = 'My first level'
@@ -57,7 +52,7 @@ The above snippet defines a simple level that looks like this:
 
 ### Loading a level from a file
 ```python
-from elma.models import Level
+from elma import Level
 
 level = Level.load('mylevel.lev')
 ```
@@ -71,7 +66,7 @@ level.save('mylevel.lev')
 
 ### Merging level top10s
 ```python
-from elma.models import Level
+from elma import Level
 
 level1 = Level.load('mylevel1.lev')
 level2 = Level.load('mylevel2.lev')
@@ -84,7 +79,7 @@ if level1 == level2:
 
 ### Loading a replay from a file
 ```python
-from elma.models import Replay
+from elma import Replay
 
 replay = Replay.load('myreplay.rec')
 ```

--- a/elma/__init__.py
+++ b/elma/__init__.py
@@ -1,0 +1,13 @@
+import elma.error
+import elma.lgr
+import elma.models
+import elma.render
+
+from .error import *
+from .lgr import *
+from .models import *
+from .render import *
+
+__all__ = (
+    elma.error.__all__ + elma.lgr.__all__ + elma.models.__all__ + elma.render.__all__
+)

--- a/elma/error.py
+++ b/elma/error.py
@@ -7,6 +7,8 @@ from elma.lgr import LGR, LGR_Image
 from elma.constants import LGR_MANDATORY_FILES
 from elma.constants import LGR_LIMITED_SIZE_FILES
 
+__all__ = ["check_LGR_error"]
+
 LGR_PCX_MIN = 10    # unused as practically never important
 LGR_PCX_MAX = 3500    # unused as practically never important
 LGR_PCX_FILESIZE_MIN = 1    # unused as practically never important

--- a/elma/lgr.py
+++ b/elma/lgr.py
@@ -16,6 +16,8 @@ from elma.constants import LGR_PCX_PADDING
 from elma.constants import LGR_PICTURES_LST_ID
 from elma.utils import null_padded
 
+__all__ = ["LGR_Image", "LGR", "unpack_LGR", "pack_LGR"]
+
 
 class LGR_Image(object):
     """

--- a/elma/models.py
+++ b/elma/models.py
@@ -14,6 +14,25 @@ from elma.constants import VERSION_ELMA
 from elma.render import LevelRenderer
 from elma.utils import null_padded, BoundingBox, check_writable_file
 
+__all__ = [
+    "Point",
+    "Obj",
+    "Picture",
+    "Polygon",
+    "Top10Time",
+    "Top10",
+    "Level",
+    "Frame",
+    "Event",
+    "ObjectTouchEvent",
+    "TurnEvent",
+    "LeftVoltEvent",
+    "RightVoltEvent",
+    "GroundTouchEvent",
+    "AppleTouchEvent",
+    "Replay",
+]
+
 
 class Point(object):
     """

--- a/elma/packing.py
+++ b/elma/packing.py
@@ -12,6 +12,8 @@ from elma.constants import END_OF_FILE_MARKER
 from elma.constants import END_OF_REPLAY_FILE_MARKER
 from elma.utils import null_padded, crypt_top10
 
+__all__ = ["pack_level", "unpack_level", "pack_replay", "unpack_replay"]
+
 if TYPE_CHECKING:
     # defined here to avoid circular import at runtime
     LevelItem = Union[

--- a/elma/render.py
+++ b/elma/render.py
@@ -5,6 +5,8 @@ from PIL import Image, ImageDraw
 import elma.models
 from elma.constants import OBJECT_RADIUS
 
+__all__ = ["LevelRenderer"]
+
 
 class LevelRenderer:
 

--- a/elma/utils.py
+++ b/elma/utils.py
@@ -2,6 +2,8 @@ from collections import namedtuple
 from pathlib import Path
 from typing import Union
 
+__all__ = ["null_padded", "signed_mod", "crypt_top10", "check_writable_file", "BoundingBox"]
+
 
 def null_padded(string: str, length: int) -> bytes:
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,8 @@
 [flake8]
 max_line_length = 120
+# F401: imported but unused
+# F403: from module import * used; unable to detect undefined names
+per-file-ignores = __init__.py: F401, F403
 
 [mypy]
 python_version = 3.7


### PR DESCRIPTION
This PR simplifies the public API so that most classes and functions can be imported directly from the main package instead of submodules. The public API is also decoupled from the internal code structure to make it easier to change code without breaking the public API in future. Also __all__ has been added to most files to allow safer import * just in case.